### PR TITLE
Support for implicit multiplication via concat

### DIFF
--- a/js/grammar.jison
+++ b/js/grammar.jison
@@ -66,11 +66,35 @@ explist
 	  { $explist.push($exp); $$ = $explist; }
 	;
 
+concat_mult
+	: number identifier
+	  -> yy.multiply($number, $identifier)
+	| number number
+	  -> yy.multiply($number1, $number2)
+	| number paren_exp
+	  -> yy.multiply($number, $paren_exp)
+	| identifier number
+	  -> yy.multiply($number, $identifier)
+	| identifier identifier
+	  -> yy.multiply($identifier1, $identifier2)
+	// No identifier paren_exp; can be a function call
+	| paren_exp identifier
+	  -> yy.multiply($paren_exp, $identifier)
+	| paren_exp number
+	  -> yy.multiply($paren_exp, $number)
+	| paren_exp paren_exp
+	  -> yy.multiply($paren_exp1, $paren_exp2)
+	;
+
+paren_exp
+	: LPAREN exp RPAREN -> $exp
+	;
+
 exp
 	: number
 	| identifier
-	| number identifier
-	  -> yy.multiply($number, $identifier)
+	| concat_mult
+	| paren_exp
 	| exp INVOLUTION
 	  -> yy.involute($exp)
 	| exp CONJUGATE
@@ -79,7 +103,6 @@ exp
 	  -> yy.negate($exp)
 	| exp WS exp // a multiplication; TODO
 	  -> yy.multiply($exp1, $exp2);
-	| LPAREN exp RPAREN -> $exp
 
 	| exp PLUS exp
 	   -> yy.add($exp1,$exp2)

--- a/test/test_jison_parser.js
+++ b/test/test_jison_parser.js
@@ -1,28 +1,30 @@
 var parser = require("../js/grammar").parser;
 
+var nop_yy = {
+	assignment: function (identifier, exp) {},
+	identifier: function (name) {},
+	number: parseFloat,
+
+	negate: function (exp) {},
+	conjugate: function (exp) {},
+	involute: function (exp) {},
+
+	add: function(exp1, exp2) {},
+	subtract: function(exp1, exp2) {},
+	power: function(exp1, exp2) {},
+	outerPower: function(exp1, exp2) {},
+	multiply: function(exp1, exp2) {},
+	innerProduct: function(exp1, exp2) {},
+	outerProduct: function(exp1, exp2) {},
+	div: function(exp1, exp2) {},
+	backdiv: function(exp1, exp2) {},
+
+	funcall: function(name, args) {}
+};
+
 // Just a simple test that the parser recognises the language
 exports.testRecognition = function(test) {
-	parser.yy = {
-		assignment: function (identifier, exp) {},
-		identifier: function (name) {},
-		number: parseFloat,
-
-		negate: function (exp) {},
-		conjugate: function (exp) {},
-		involute: function (exp) {},
-
-		add: function(exp1, exp2) {},
-		subtract: function(exp1, exp2) {},
-		power: function(exp1, exp2) {},
-		outerPower: function(exp1, exp2) {},
-		multiply: function(exp1, exp2) {},
-		innerProduct: function(exp1, exp2) {},
-		outerProduct: function(exp1, exp2) {},
-		div: function(exp1, exp2) {},
-		backdiv: function(exp1, exp2) {},
-
-		funcall: function(name, args) {}
-	};
+	parser.yy = nop_yy;
 
 	parser.parse("a");
 	parser.parse("e123");
@@ -35,13 +37,21 @@ exports.testRecognition = function(test) {
 	parser.parse("x ");
 	parser.parse("x / y + 1");
 	parser.parse("Pu(x,1)");
-	// More complex stuff
-	// TODO: Perhaps have these separate
+	test.done();
+}
+
+exports.testImplicitMultiplication = function(test) {
+	parser.yy = nop_yy;
+
 	parser.parse("a = 2e1 (e2 + e3)");
 	parser.parse("a = 2e1 (e2 + e3) ");
 	parser.parse("a = (2e1+e2)(e2 + e3)");
 	parser.parse("e1 2");
 	parser.parse("e1 2x");
+	parser.parse("1 2");
+	parser.parse("5(e1+e2)");
+	parser.parse("x y");
+	parser.parse("(e1+e2)x");
 	test.done();
 }
 

--- a/test/test_jison_parser.js
+++ b/test/test_jison_parser.js
@@ -36,8 +36,12 @@ exports.testRecognition = function(test) {
 	parser.parse("x / y + 1");
 	parser.parse("Pu(x,1)");
 	// More complex stuff
+	// TODO: Perhaps have these separate
 	parser.parse("a = 2e1 (e2 + e3)");
 	parser.parse("a = 2e1 (e2 + e3) ");
+	parser.parse("a = (2e1+e2)(e2 + e3)");
+	parser.parse("e1 2");
+	parser.parse("e1 2x");
 	test.done();
 }
 


### PR DESCRIPTION
Handles most cases except "identifier parens".

Tests could actually check that proper multiplication is carried out; currently they just check that grammar checks out.
